### PR TITLE
test(api): add healthcheck test and use commonjs export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Healthcheck (verifica se as variáveis de ambiente estão configuradas):
 curl -s https://SEU-APP.vercel.app/api/chat | jq
 # {
 #   "ok": true,
-#   "hasEnv": { "CHAT_WEBHOOK_URL": true, ... }
+#   "env": { "CHAT_WEBHOOK_URL": true, ... }
 # }
 ```
 

--- a/__tests__/chat.test.js
+++ b/__tests__/chat.test.js
@@ -39,8 +39,23 @@ describe('/api/chat', () => {
     expect(res._getData()).toBe(JSON.stringify({ ok: true }));
   });
 
-  it('rejects non-POST requests', async () => {
+  it('returns healthcheck on GET', async () => {
     const { req, res } = createMocks({ method: 'GET' });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.ok).toBe(true);
+    expect(data.env).toMatchObject({
+      CHAT_WEBHOOK_URL: true,
+      CHAT_BASIC_USER: true,
+      CHAT_BASIC_PASS: true,
+      CHAT_SHARED_SECRET: true,
+      ALLOWED_ORIGIN: expect.any(String),
+    });
+  });
+
+  it('rejects unsupported methods', async () => {
+    const { req, res } = createMocks({ method: 'PUT' });
     await handler(req, res);
     expect(res._getStatusCode()).toBe(405);
   });

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -7,7 +7,7 @@ function setCors(res) {
   res.setHeader("Access-Control-Max-Age", "86400");
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   setCors(res);
 
   if (req.method === "OPTIONS") return res.status(204).end();
@@ -56,3 +56,4 @@ export default async function handler(req, res) {
   }
 }
 
+module.exports = handler;


### PR DESCRIPTION
## Summary
- switch `/api/chat` to CommonJS export for compatibility
- add tests for GET healthcheck and unsupported methods
- document healthcheck `env` flags in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a202c0d89883268a437381da796a27