### PR TITLE
Fix Next.js build by removing Babel config

### DIFF
--- a/__tests__/chat.test.js
+++ b/__tests__/chat.test.js
@@ -1,4 +1,4 @@
-const handler = require('../pages/api/chat').default;
+const handler = require('../pages/api/chat');
 const { createMocks } = require('node-mocks-http');
 
 describe('/api/chat', () => {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['@babel/preset-env'],
-};

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -56,4 +56,4 @@ async function handler(req, res) {
   }
 }
 
-export default handler;
+module.exports = handler;


### PR DESCRIPTION
## Summary
- remove custom Babel config and switch chat API route to CommonJS export
- adjust tests to match new export style

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a208ab822c83269bc1b63d56a64d8c