### PR TITLE
Convert chat API to ESM default export

### DIFF
--- a/__tests__/chat.test.js
+++ b/__tests__/chat.test.js
@@ -1,5 +1,5 @@
-const handler = require('../pages/api/chat');
-const { createMocks } = require('node-mocks-http');
+import handler from '../pages/api/chat.js';
+import { createMocks } from 'node-mocks-http';
 
 describe('/api/chat', () => {
   beforeEach(() => {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  transform: {
+    '^.+\\.js$': ['babel-jest', { presets: ['@babel/preset-env'] }],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "jest": "^30.0.5",
     "next": "^15.4.6",

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -7,7 +7,7 @@ function setCors(res) {
   res.setHeader("Access-Control-Max-Age", "86400");
 }
 
-async function handler(req, res) {
+export default async function handler(req, res) {
   setCors(res);
 
   if (req.method === "OPTIONS") return res.status(204).end();
@@ -55,5 +55,3 @@ async function handler(req, res) {
     return res.status(500).json({ error: "Failed to call webhook", detail: err?.message || "unknown" });
   }
 }
-
-module.exports = handler;


### PR DESCRIPTION
## Summary
- update chat API route to use an async default export
- switch project to ESM and update tests/config

## Testing
- `npm test`
- `npm run build`
- `curl -s http://localhost:3001/api/chat`


------
https://chatgpt.com/codex/tasks/task_e_68a2141bba5c8326bc22a218de0520dd